### PR TITLE
Fix macro summary lookup and slots

### DIFF
--- a/src/components/PlannerMacroSummary.jsx
+++ b/src/components/PlannerMacroSummary.jsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from "react";
 
 const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-const slots = ["Breakfast", "Snack 1", "Lunch", "Snack 2", "Dinner"];
+const slots = ["Breakfast", "Snack 1", "Lunch", "Snack 2", "Dinner", "Smoothie"];
 
 export default function PlannerMacroSummary() {
   const [planner, setPlanner] = useState({});
@@ -18,7 +18,7 @@ export default function PlannerMacroSummary() {
   }, []);
 
   const calculateMealMacros = (mealId) => {
-    const meal = meals.find(m => m.id === Number(mealId));
+    const meal = meals.find(m => m.id === mealId);
     if (!meal) return null;
 
     const total = { calories: 0, protein: 0, carbs: 0, fat: 0, fibre: 0 };


### PR DESCRIPTION
## Summary
- handle meal IDs as strings in PlannerMacroSummary
- include "Smoothie" slot in macro summary

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867ef291c448327ad394701cd516c8c