### PR TITLE
Add empty-recipe test and fix computeMealMacros

### DIFF
--- a/src/utils/macroUtils.js
+++ b/src/utils/macroUtils.js
@@ -38,6 +38,7 @@ export function computeMealMacros(meal, ingredients, recipes, portion = 1.0) {
       source = recipes[comp.id];
       if (!source || !source.ingredients) return;
       const { totalMacros, totalWeight } = computeRecipeMacros(source, ingredients);
+      if (totalWeight <= 0) return;
       const recipeScale = grams / totalWeight;
       for (const key in totals) {
         totals[key] += totalMacros[key] * recipeScale;

--- a/src/utils/macroUtils.test.js
+++ b/src/utils/macroUtils.test.js
@@ -47,4 +47,20 @@ describe('computeMealMacros', () => {
     expect(macros.fat).toBeCloseTo(3.7);
     expect(macros.fibre).toBe(0);
   });
+
+  it('returns zero macros for an empty recipe', () => {
+    const emptyRecipe = { id: 'empty', ingredients: [] };
+    const recipes = { empty: emptyRecipe };
+    const meal = {
+      components: [
+        { type: 'recipe', id: 'empty', quantityGrams: 100 }
+      ]
+    };
+    const macros = computeMealMacros(meal, ingredients, recipes);
+    expect(macros.calories).toBe(0);
+    expect(macros.protein).toBe(0);
+    expect(macros.carbs).toBe(0);
+    expect(macros.fat).toBe(0);
+    expect(macros.fibre).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- guard against division by zero in `computeMealMacros`
- test that meals using empty recipes return zero macros

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68680a60b6a48327a1bfa073a297be61