### PR TITLE
Add test for unknown ingredients

### DIFF
--- a/src/utils/macroUtils.test.js
+++ b/src/utils/macroUtils.test.js
@@ -63,4 +63,19 @@ describe('computeMealMacros', () => {
     expect(macros.fat).toBe(0);
     expect(macros.fibre).toBe(0);
   });
+
+  it('ignores unknown ingredients when computing macros', () => {
+    const meal = {
+      components: [
+        { type: 'ingredient', id: 'mystery_item', quantityGrams: 50 },
+        { type: 'ingredient', id: 'chicken_breast', quantityGrams: 100 }
+      ]
+    };
+    const macros = computeMealMacros(meal, ingredients, {});
+    expect(macros.calories).toBeCloseTo(165);
+    expect(macros.protein).toBeCloseTo(31);
+    expect(macros.carbs).toBe(0);
+    expect(macros.fat).toBeCloseTo(3.6);
+    expect(macros.fibre).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- verify that `computeMealMacros` skips invalid ingredient IDs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686810e7a17c832787ff48d2131c6749