### PR TITLE
Fix RecipeBuilder ingredient ID handling

### DIFF
--- a/src/components/RecipeBuilder.jsx
+++ b/src/components/RecipeBuilder.jsx
@@ -92,7 +92,7 @@ export default function RecipeBuilder({ onSave, selectedRecipe }) {
       />
 
       <select
-        onChange={(e) => addComponent(Number(e.target.value))}
+        onChange={(e) => addComponent(e.target.value)}
         className="border border-border-default px-2 py-1 w-full"
         defaultValue=""
       >
@@ -139,7 +139,7 @@ RecipeBuilder.propTypes = {
     name: PropTypes.string,
     components: PropTypes.arrayOf(
       PropTypes.shape({
-        ingredientId: PropTypes.number.isRequired,
+        ingredientId: PropTypes.string.isRequired,
         quantityGrams: PropTypes.number.isRequired,
       })
     ),


### PR DESCRIPTION
## Summary
- keep ingredient IDs as strings when adding components
- update RecipeBuilder propTypes accordingly

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686810da41408327990d2544b01f65ca