### PR TITLE
Fix unused vars across components

### DIFF
--- a/src/app/IngredientApp.jsx
+++ b/src/app/IngredientApp.jsx
@@ -8,15 +8,12 @@ import ingredientSeed from "../data/ingredients";
 export default function IngredientApp() {
   const [selected, setSelected] = useState(null);
   const [refreshKey, setRefreshKey] = useState(0);
-  const [ingredients, setIngredients] = useState([]);
 
   useEffect(() => {
     if (!localStorage.getItem("ingredients")) {
       const ingredientsArray = Object.values(ingredientSeed);
       localStorage.setItem("ingredients", JSON.stringify(ingredientsArray));
     }
-    const stored = localStorage.getItem("ingredients");
-    if (stored) setIngredients(JSON.parse(stored));
   }, [refreshKey]);
 
   const handleSave = () => {

--- a/src/components/AutoPlannerButton.jsx
+++ b/src/components/AutoPlannerButton.jsx
@@ -5,8 +5,6 @@ import { autoGeneratePlan } from "../utils/autoPlanner.mjs";
 export default function AutoPlannerButton({ onRefresh }) {
   const handleClick = () => {
     try {
-      const macroTargets = JSON.parse(localStorage.getItem("macroTargets") || "{}");
-
       const mealsRaw = JSON.parse(localStorage.getItem("meals") || "[]");
       const recipesRaw = JSON.parse(localStorage.getItem("recipes") || "[]");
       const ingredientsRaw = JSON.parse(localStorage.getItem("ingredients") || "[]");

--- a/src/components/MacroTargetEditor.jsx
+++ b/src/components/MacroTargetEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";

--- a/src/components/PlannerGrid.jsx
+++ b/src/components/PlannerGrid.jsx
@@ -13,7 +13,7 @@ const days = [
 
 const slots = ["Breakfast", "Snack 1", "Lunch", "Snack 2", "Dinner", "Smoothie"];
 
-export default function PlannerGrid({ macroTargets, setMacroTargets }) {
+export default function PlannerGrid({ macroTargets }) {
   const [meals, setMeals] = useState({});
   const [plan, setPlan] = useState({});
   const [ingredients, setIngredients] = useState({});

--- a/src/components/PlannerMacroSummary.jsx
+++ b/src/components/PlannerMacroSummary.jsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from "react";
 
 const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
-const slots = ["Breakfast", "Snack 1", "Lunch", "Snack 2", "Dinner", "Smoothie"];
 
 export default function PlannerMacroSummary() {
   const [planner, setPlanner] = useState({});


### PR DESCRIPTION
## Summary
- clean up macro target retrieval in auto planner
- drop unused ingredient state
- trim React hook imports
- remove unused props
- delete old constant

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6868282b04f48327b93e895678e00383